### PR TITLE
gh-93607: document `root` attribute of `iterparse`

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -627,6 +627,9 @@ Functions
    blocking reads on *source* (or the file it names).  As such, it's unsuitable
    for applications where blocking reads can't be made.  For fully non-blocking
    parsing, see :class:`XMLPullParser`.
+   
+   Once *source* is fully read, the returned :term:`iterator` object is populated with `root`
+   attribute which references to the root element of the resulting XML tree.
 
    .. note::
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -628,7 +628,7 @@ Functions
    for applications where blocking reads can't be made.  For fully non-blocking
    parsing, see :class:`XMLPullParser`.
    
-   Once *source* is fully read, the returned :term:`iterator` object is populated with `root`
+   Once *source* is fully read, the returned :term:`iterator` object is populated with a ``root``
    attribute which references to the root element of the resulting XML tree.
 
    .. note::


### PR DESCRIPTION
Issue #93607